### PR TITLE
[RND-3432] ci: add backport workflows and instructions comment

### DIFF
--- a/.github/workflows/backport-instructions.yml
+++ b/.github/workflows/backport-instructions.yml
@@ -1,0 +1,37 @@
+name: Backport instructions comment
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment with backport instructions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post instructions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Post a short how-to for backport labels and the /backport trigger.
+            const pr = context.payload.pull_request
+            const body = [
+              "Backport instructions:",
+              "",
+              "- Add labels like `backport scarthgap_6.6.52-2.2.2_var01` before merging.",
+              "- If you add labels after merge, comment `/backport` to trigger the backport run.",
+              "",
+              "Examples:",
+              "- `backport walnascar_6.12.20-2.0.0_var01`",
+              "- `backport scarthgap_6.6.52-2.2.2_var01`",
+            ].join("\\n")
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            })

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,32 @@
+name: Backport labeled merged pull requests
+
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Create backport PRs
+    runs-on: ubuntu-latest
+    # Run on merge, or on manual /backport comment after merge.
+    # Guard against backport-action bot comments retriggering the workflow.
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        startsWith(github.event.comment.body, '/backport')
+      )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport PRs
+        uses: korthout/backport-action@v4


### PR DESCRIPTION
Add a backport workflow that runs on merged PRs or /backport comments Use korthout/backport-action to open backport PRs based on labels Post a short how-to comment when PRs are opened